### PR TITLE
QR fix

### DIFF
--- a/pages/src/widget_qr.rs
+++ b/pages/src/widget_qr.rs
@@ -153,14 +153,12 @@ pub fn generate_qr_svgs(ptc_file: PtcData, config : QrConfig) -> Result<Vec<Stri
         qrdata.extend_from_slice(resultslice);
         println!("QR {} size: {}", qrnum + 1, qrdata.len());
         let mut qrbits = qrcode::bits::Bits::new(qrcode::Version::Normal(config.qr_version));
-        qrbits
-            .push_byte_data(&qrdata)
+        qrbits.push_byte_data(&qrdata)
             .map_err(|e| Error::Other(e.to_string()))?;
-            qrbits
-                .push_terminator(config.error_level)
-                .map_err(|e| Error::Other(e.to_string()))?;
-                let code = QrCode::with_bits(qrbits, config.error_level)
-                .map_err(|e| Error::Other(e.to_string()))?;
+        qrbits.push_terminator(config.error_level)
+            .map_err(|e| Error::Other(e.to_string()))?;
+        let code = QrCode::with_bits(qrbits, config.error_level)
+            .map_err(|e| Error::Other(e.to_string()))?;
         let image = code.render()
             .min_dimensions(config.min_size, config.min_size)
             .dark_color(svg::Color("#000000"))


### PR DESCRIPTION
This fix avoids the QR library's optimizer and sets the QR data sizes to their correct values. I have tested the generation standalone and it produced working QRs, but I haven't tested the full website running with this fix. I only touched the one file so this shouldn't break anything else.