### PR TITLE
sbs: url scheme for 12y

### DIFF
--- a/static/layout.js
+++ b/static/layout.js
@@ -1,6 +1,26 @@
 //The website is designed to have maximum usability without javascript. As such, most of what
 //you'll find here are quality of life improvements
 
+//change Markup link handler for sbs: scheme
+//mainly convenient for docs links after import
+Markup.renderer.url_scheme['sbs:'] = (url, thing) => {
+    var slashidx = url.pathname.indexOf("/")
+    var front = url.pathname.slice(0,slashidx);
+    var back = url.pathname.slice(slashidx+1);
+    var lunk;
+    
+    switch(front) {
+        case "page":
+            lunk = "/forum/thread/"+back;
+            break;
+        default:
+            lunk = "/"+url.pathname;
+            break;
+    }
+    
+    return SBSBASEURL+lunk;
+};
+
 //This all happens on "defer" so it's fine to do it out in the open like this
 upgrade_forms();
 upgrade_markupeditors();


### PR DESCRIPTION
This allows URLs in 12y to be written as `sbs:page/hash` or `sbs:user/name` etc. to link to content easily. This won't fix all the currently broken links because they're all old page IDs but this will make them easier to edit. Also this could be good for static docs export later (easier to figure out where all of the links go, which ones are internal etc)