### PR TITLE
Code CSS changes for 12y pages

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -1,3 +1,5 @@
+/* import css overrides for 12y pages */
+@import url("custom_12y.css");
 
 /* all the css variables to control common document constants */
 :root {

--- a/static/custom_12y.css
+++ b/static/custom_12y.css
@@ -1,0 +1,33 @@
+/* site CSS rules for 12y pages */
+/* these changes are primarily for consistency with the rest of the site */
+
+
+/* why such an aggressive rule??? */
+.Markup, .Markup * {
+	word-break: unset !important;
+}
+
+.Markup code {
+	/* match look on the rest of the site */
+	background: transparent !important;
+	font-family: monospace !important;
+	padding: initial !important;
+	color: var(--tc_error) !important;
+	/* should icode be bold? */
+	font-weight: bold;
+	font-size: unset !important;
+}
+
+.Markup code, .Markup pre {
+	/* fix flow issues with code
+	 * (i dont even know why it was set how it was)
+	 * ideally this will force layout to take break opportunities elsewhere */
+	line-break: normal !important;
+	word-break: keep-all !important;
+	hyphens: none;
+	overflow-wrap: break-word;
+}
+
+.Markup pre {
+	overflow-x: auto;
+}

--- a/static/layout.js
+++ b/static/layout.js
@@ -2,7 +2,6 @@
 //you'll find here are quality of life improvements
 
 //change Markup link handler for sbs: scheme
-//mainly convenient for docs links after import
 Markup.renderer.url_scheme['sbs:'] = (url, thing) => {
     var slashidx = url.pathname.indexOf("/")
     var front = url.pathname.slice(0,slashidx);
@@ -12,6 +11,9 @@ Markup.renderer.url_scheme['sbs:'] = (url, thing) => {
     switch(front) {
         case "page":
             lunk = "/forum/thread/"+back;
+            break;
+        case "docs":
+            lunk = "/forum/thread/docs-"+back;
             break;
         default:
             lunk = "/"+url.pathname;


### PR DESCRIPTION
I've adjusted the styles for icode and code (`.Markup code` and `.Markup pre`) for 12y. They now should look identical to bbcode pages and icode should not be the first target of word breaks in tables anymore. These changes are added to an `@include`-d stylesheet `static/custom_12y.css`

An example:
![example of markup changes](https://user-images.githubusercontent.com/12587624/232890464-1e9d0389-70d9-44b1-8457-2eb164ca429a.png)
Before:
![table icode under current styles](https://user-images.githubusercontent.com/12587624/232890531-8734ba51-ddd3-4bbb-a5fa-05381f66ae09.png)

After:
![table icode under new styles](https://user-images.githubusercontent.com/12587624/232890592-ba3eaebd-5210-40ee-b54e-09f1fa20c5ac.png)

Commits also include a `sbs:docs/` link format as a shorthand for docs link hashes